### PR TITLE
Add possibility to provide a custom magic-file

### DIFF
--- a/README.md
+++ b/README.md
@@ -15,6 +15,8 @@ npm install stream-mmmagic
 ## Use
 ```
 var magic = require('stream-mmmagic');
+// optional: provide custom magic-file
+magic.config.magicFile = 'path/to/custom/magic/file';
 
 var input = fs.createReadStream('somefile.csv');
 

--- a/lib/stream-mmmagic.js
+++ b/lib/stream-mmmagic.js
@@ -6,7 +6,9 @@ function streamMmmagic(stream, callback) {
   // accurately detecting the encoding
   return peek(stream, 16384, function (err, buf, dest) {
     if (err) return callback(err, null, dest);
-    var magic = new mmm.Magic(mmm.MAGIC_MIME);
+    var magic = config.magicFile
+        ? new mmm.Magic(config.magicFile, mmm.MAGIC_MIME)
+        : new mmm.Magic(mmm.MAGIC_MIME);
     magic.detect(buf, function (err, res) {
       if (err) return callback(err, null, dest);
       callback(null, splitMime(res), dest);
@@ -14,6 +16,11 @@ function streamMmmagic(stream, callback) {
   });
 }
 
+var config = {
+    magicFile: null
+};
+
+streamMmmagic.config = config;
 module.exports = streamMmmagic;
 
 var _splitMime = /^(.*); charset=(.*)$/;


### PR DESCRIPTION
I would like to use `stream-mmmagic` in my project, but I have the problem that it does not detect `video/m2pt` files as the magic-number is not part of the default 

[This post](http://unix.stackexchange.com/questions/129081/file-doesn-t-show-proper-mime-type-for-m2ts-files) describes how to write a magic-file that detects m2ts-files, but `stream-mmmagic` does not offer a way to provide a custom magic file. This pull-request includes that ability. If you think you'd rather do it another way, please do so. I would however, very much like to use this module as it is exactly what I need.
