### PR TITLE
bump mmmagic

### DIFF
--- a/package.json
+++ b/package.json
@@ -27,6 +27,6 @@
   "homepage": "https://github.com/seangarner/node-stream-mmmagic",
   "dependencies": {
     "buffer-peek-stream": "^0.2.0",
-    "mmmagic": "^0.3.11"
+    "mmmagic": "^0.4.11"
   }
 }

--- a/package.json
+++ b/package.json
@@ -27,6 +27,6 @@
   "homepage": "https://github.com/seangarner/node-stream-mmmagic",
   "dependencies": {
     "buffer-peek-stream": "^0.2.0",
-    "mmmagic": "^0.4.11"
+    "mmmagic": "^0.4.1"
   }
 }


### PR DESCRIPTION
[faced issue](https://travis-ci.org/iamstarkov/jsunderhood/builds/87626437#L102) with nodejs v4 #2, and it seems like stream-mmmagic is using old mmmagic. hopefully it will work now