### PR TITLE
Possibility to disable mime type splitting

### DIFF
--- a/lib/stream-mmmagic.js
+++ b/lib/stream-mmmagic.js
@@ -11,13 +11,14 @@ function streamMmmagic(stream, callback) {
         : new mmm.Magic(mmm.MAGIC_MIME);
     magic.detect(buf, function (err, res) {
       if (err) return callback(err, null, dest);
-      callback(null, splitMime(res), dest);
+      callback(null, config.splitMime ? splitMime(res) : res, dest);
     });
   });
 }
 
 var config = {
-    magicFile: null
+    magicFile: null,
+    splitMime: true
 };
 
 streamMmmagic.config = config;


### PR DESCRIPTION
Possibility to obtain directly the complete mime type (with encoding) as a string, without the splitting phase.