### PR TITLE
Create Magic object once

### DIFF
--- a/lib/stream-mmmagic.js
+++ b/lib/stream-mmmagic.js
@@ -1,6 +1,8 @@
 var mmm = require('mmmagic');
 var peek = require('buffer-peek-stream');
 
+var magicMime = new mmm.Magic(mmm.MAGIC_MIME);
+
 function streamMmmagic(stream, options, callback) {
 
   if (!callback) {
@@ -20,7 +22,7 @@ function streamMmmagic(stream, options, callback) {
 
     var magic = magicFile
         ? new mmm.Magic(magicFile, mmm.MAGIC_MIME)
-        : new mmm.Magic(mmm.MAGIC_MIME);
+        : magicMime;
 
     magic.detect(buf, function (err, res) {
       if (err) return callback(err, null, dest);

--- a/lib/stream-mmmagic.js
+++ b/lib/stream-mmmagic.js
@@ -1,8 +1,6 @@
 var mmm = require('mmmagic');
 var peek = require('buffer-peek-stream');
 
-var magicMime = new mmm.Magic(mmm.MAGIC_MIME);
-
 function streamMmmagic(stream, options, callback) {
 
   if (!callback) {
@@ -20,9 +18,18 @@ function streamMmmagic(stream, options, callback) {
   return peek(stream, 16384, function (err, buf, dest) {
     if (err) return callback(err, null, dest);
 
-    var magic = magicFile
-        ? new mmm.Magic(magicFile, mmm.MAGIC_MIME)
-        : magicMime;
+    var magic;
+    if (magicFile) {
+      if (magicFiles.hasOwnProperty(magicFile)) {
+        magic = magicFiles[magicFile];
+      }
+      else {
+        magic = magicFiles[magicFile] = new mmm.Magic(magicFile, mmm.MAGIC_MIME);
+      }
+    }
+    else {
+      magic = _magic;
+    }
 
     magic.detect(buf, function (err, res) {
       if (err) return callback(err, null, dest);
@@ -34,6 +41,8 @@ function streamMmmagic(stream, options, callback) {
   });
 }
 
+var _magic = new mmm.Magic(mmm.MAGIC_MIME);
+var magicFiles = {};
 var config = {
     magicFile: null
 };

--- a/test.js
+++ b/test.js
@@ -54,4 +54,16 @@ describe('stream-mmmagic', () => {
     });
   });
 
+  it('should create new Magic object if a magicFile is specified', (done) => {
+    magic.config.magicFile = 'node_modules/mmmagic/magic/magic.mgc';
+    magic(getStream(), (err, mime, output) => {
+      if (err) return done(err);
+      expect(mime).to.eql({
+        type: 'text/plain',
+        encoding: 'utf-8'
+      });
+      done();
+    });
+  });
+
 });


### PR DESCRIPTION
Fixes #7 

Instead of creating a new `Magic` object on every call, a new object is created on initialization. If a `magicFile` is specified, a new `Magic` object is created for that file and is cached.