### PR TITLE
Improve typings 

### DIFF
--- a/lib/stream-mmmagic.d.ts
+++ b/lib/stream-mmmagic.d.ts
@@ -1,12 +1,20 @@
 declare module 'stream-mmmagic' {
   import ReadableStream = NodeJS.ReadableStream
 
-  export type MimeType = string | {
+  type MimeType = {
       type: string,
       encoding: string
   }
 
-  export interface SniffStreamMimeTypeOptions {
+  interface SplitMime {
+      splitMime?: true
+  }
+
+  interface DoNotSplitMime {
+      splitMime: false
+  }
+
+  interface SniffStreamMimeTypeOptions {
       magicFile?: string
       splitMime?: boolean
       peekBytes?: number
@@ -20,14 +28,27 @@ declare module 'stream-mmmagic' {
 
       (
           input: ReadableStream,
-          options: SniffStreamMimeTypeOptions,
+          options: SniffStreamMimeTypeOptions & SplitMime,
           callback: (error: Error, mime: MimeType, output: ReadableStream) => void
       ): void
 
-      promise (input: ReadableStream, options?: SniffStreamMimeTypeOptions): Promise<[MimeType, ReadableStream]>
+      (
+        input: ReadableStream,
+        options: SniffStreamMimeTypeOptions & DoNotSplitMime,
+        callback: (error: Error, mime: string, output: ReadableStream) => void
+      ): void
+
+      (
+        input: ReadableStream,
+        options: SniffStreamMimeTypeOptions,
+        callback: (error: Error, mime: string | MimeType, output: ReadableStream) => void
+      ): void
+
+      promise (input: ReadableStream, options?: SniffStreamMimeTypeOptions & SplitMime): Promise<[MimeType, ReadableStream]>
+      promise (input: ReadableStream, options: SniffStreamMimeTypeOptions & DoNotSplitMime): Promise<[string, ReadableStream]>
+      promise (input: ReadableStream, options: SniffStreamMimeTypeOptions): Promise<[string | MimeType, ReadableStream]>
   }
 
   const sniffStreamMimeType: SniffStreamMimeType
-
-  export default sniffStreamMimeType
+  export = sniffStreamMimeType
 }

--- a/package-lock.json
+++ b/package-lock.json
@@ -4,6 +4,11 @@
   "lockfileVersion": 1,
   "requires": true,
   "dependencies": {
+    "@types/node": {
+      "version": "16.3.1",
+      "resolved": "https://registry.npmjs.org/@types/node/-/node-16.3.1.tgz",
+      "integrity": "sha512-N87VuQi7HEeRJkhzovao/JviiqKjDKMVKxKMfUvSKw+MbkbW8R0nA3fi/MQhhlxV2fQ+2ReM+/Nt4efdrJx3zA=="
+    },
     "@ungap/promise-all-settled": {
       "version": "1.1.2",
       "resolved": "https://registry.npmjs.org/@ungap/promise-all-settled/-/promise-all-settled-1.1.2.tgz",

--- a/package.json
+++ b/package.json
@@ -28,7 +28,8 @@
   "homepage": "https://github.com/seangarner/node-stream-mmmagic",
   "dependencies": {
     "buffer-peek-stream": "^1.1.0",
-    "mmmagic": "^0.5.0"
+    "mmmagic": "^0.5.0",
+    "@types/node": "*"
   },
   "devDependencies": {
     "chai": "^4.3.4",

--- a/test.ts
+++ b/test.ts
@@ -1,0 +1,39 @@
+import * as magic from 'stream-mmmagic';
+
+declare const input: NodeJS.ReadableStream
+declare const splitMime: boolean
+
+type MimeType = {
+    type: string,
+    encoding: string
+}
+
+magic(input, (error: Error, mime: MimeType, output: NodeJS.ReadableStream) => {})
+magic(input, { peekBytes: 4 * 1024 }, (error: Error, mime: MimeType, output: NodeJS.ReadableStream) => {})
+magic(input, { splitMime: true }, (error: Error, mime: MimeType, output: NodeJS.ReadableStream) => {})
+magic(input, { splitMime: false }, (error: Error, mime: string, output: NodeJS.ReadableStream) => {})
+magic(input, { splitMime }, (error: Error, mime: string | MimeType, output: NodeJS.ReadableStream) => {})
+
+// @ts-expect-error
+magic(input, { splitMime: false }, (error: Error, mime: MimeType, output: NodeJS.ReadableStream) => {})
+
+// @ts-expect-error
+magic(input, { splitMime: true }, (error: Error, mime: string, output: NodeJS.ReadableStream) => {})
+
+async function testPromise() {
+    let mimeObject: MimeType
+    let mimeString: string
+    let mimeBoth: MimeType | string
+    let output: NodeJS.ReadableStream
+
+    [mimeObject, output] = await magic.promise(input);
+    [mimeObject, output] = await magic.promise(input, { peekBytes: 4 * 1024 });
+    [mimeString, output] = await magic.promise(input, { splitMime: false });
+    [mimeBoth, output] = await magic.promise(input, { splitMime });
+
+    // @ts-expect-error
+    [mimeString, output] = await magic.promise(input);
+
+    // @ts-expect-error
+    [mimeString, output] = await magic.promise(input, { splitMime: true });
+}


### PR DESCRIPTION
- Add `@types/node` as a dependency - this is required for the NodeJS namespace to work (by the way an alternative is to publish the `.d.ts` file on https://github.com/DefinitelyTyped/DefinitelyTyped/ - this means TS users would have to import another package, but the upshot is that non-TS users won't have to transitively import the types) 
- Improve return types when `splitMime` is static - this is expected to be the case most of the time, so it seems useful to type it. It is a bit unwieldy, but the API is otherwise pretty simple and I think the improved return type is worth it 
- Fix export declaration - the module uses a CJS export, which is not default if `esModuleInterop` is not true in tsconfig, so the original typings would work in that case, but if it is unspecified the typings would actually be incorrect because it forces the caller to incorrectly use a default import 
- Add a TS test - similar to that used in DefinitelyTyped typings, useful for validating the updated typings work 